### PR TITLE
Develop

### DIFF
--- a/jpa/src/main/java/com/force/sdk/jpa/ForceMetaDataListener.java
+++ b/jpa/src/main/java/com/force/sdk/jpa/ForceMetaDataListener.java
@@ -189,10 +189,12 @@ public class ForceMetaDataListener implements MetaDataListener {
                         "Primay field name should be ID. Offending entity: ", "ID field type should be String."
                         + " Offending entity: ", cmd);
                 
-                // The only supported strategy is Identity
-                if (ammd.getValueStrategy() == null || ammd.getValueStrategy() != IdentityStrategy.IDENTITY) {
+                // The only supported strategies are Identity and Auto (Native). Auto gives the provider the choice
+                // and for Auto we choose the semantics of Identity.
+                IdentityStrategy valueStratagy = ammd.getValueStrategy();
+                if (!(IdentityStrategy.IDENTITY.equals(valueStratagy) ||  IdentityStrategy.NATIVE.equals(valueStratagy))) {
                     throw new NucleusUserException("@Id column requires value generation"
-                                                    + " @GeneratedValue(strategy = GenerationType.IDENTITY)."
+                                                    + " @GeneratedValue(strategy = GenerationType.AUTO)."
                                                     + " Offending entity: " + cmd.getFullClassName());
                 }
             }

--- a/jpa/src/main/java/com/force/sdk/jpa/ForceStoreManager.java
+++ b/jpa/src/main/java/com/force/sdk/jpa/ForceStoreManager.java
@@ -31,6 +31,7 @@ import java.util.*;
 
 import org.datanucleus.*;
 import org.datanucleus.metadata.AbstractClassMetaData;
+import org.datanucleus.metadata.IdentityStrategy;
 import org.datanucleus.plugin.PluginManager;
 import org.datanucleus.plugin.PluginRegistry;
 import org.datanucleus.store.*;
@@ -343,5 +344,21 @@ public class ForceStoreManager extends AbstractStoreManager {
      */
     public boolean isForDelete() {
         return forDelete;
+    }
+
+    @Override
+    public boolean isStrategyDatastoreAttributed(IdentityStrategy identityStrategy, boolean datastoreIdentityField) {
+        if (identityStrategy == null)
+        {
+            return false;
+        }
+
+        if (identityStrategy == IdentityStrategy.IDENTITY || identityStrategy == IdentityStrategy.NATIVE)
+        {
+            // "identity" and "native" are processed in the datastore
+            return true;
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
Support the @GeneratedValue  strategy of GenerationType.AUTO in addition to GenerationType.IDENTITY.

Unfortunately the restriction (from the previous version) that said a String id field had to be annotated with GenerationType.IDENTITY made it impossible to write portable JPA code. The other data stores (like Oracle or Postgres) expect a field annotated with a strategy of GenerationType.IDENTITY to be of type integer.

GenerationType.AUTO is a strategy that allows portable code to be written. GenerationType.AUTO allows the provider to choose the strategy and therefore we are free to choose "IDENTITY" while other data stores are allowed to choose what works best for them.
